### PR TITLE
VegaFusion: datafusion 16.1 with backports

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-benchmarks"
 description = "DataFusion Benchmarks"
-version = "16.0.0"
+version = "16.1.0"
 edition = "2021"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 homepage = "https://github.com/apache/arrow-datafusion"
@@ -34,7 +34,7 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 arrow = "29.0.0"
-datafusion = { path = "../datafusion/core", version = "16.0.0", features = ["scheduler"] }
+datafusion = { path = "../datafusion/core", version = "16.1.0", features = ["scheduler"] }
 env_logger = "0.10"
 futures = "0.3"
 mimalloc = { version = "0.1", optional = true, default-features = false }
@@ -51,4 +51,4 @@ test-utils = { path = "../test-utils/", version = "0.1.0" }
 tokio = { version = "^1.0", features = ["macros", "rt", "rt-multi-thread", "parking_lot"] }
 
 [dev-dependencies]
-datafusion-proto = { path = "../datafusion/proto", version = "16.0.0" }
+datafusion-proto = { path = "../datafusion/proto", version = "16.1.0" }

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-version = "16.0.0"
+version = "16.1.0"
 dependencies = [
  "ahash",
  "arrow",
@@ -698,7 +698,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-cli"
-version = "16.0.0"
+version = "16.1.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "16.0.0"
+version = "16.1.0"
 dependencies = [
  "arrow",
  "chrono",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr"
-version = "16.0.0"
+version = "16.1.0"
 dependencies = [
  "ahash",
  "arrow",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-optimizer"
-version = "16.0.0"
+version = "16.1.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "16.0.0"
+version = "16.1.0"
 dependencies = [
  "ahash",
  "arrow",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-row"
-version = "16.0.0"
+version = "16.1.0"
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-version = "16.0.0"
+version = "16.1.0"
 dependencies = [
  "arrow-schema",
  "datafusion-common",

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-cli"
 description = "Command Line Client for DataFusion query engine."
-version = "16.0.0"
+version = "16.1.0"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 edition = "2021"
 keywords = [ "arrow", "datafusion", "query", "sql" ]
@@ -32,7 +32,7 @@ readme = "README.md"
 arrow = "29.0.0"
 async-trait = "0.1.41"
 clap = { version = "3", features = ["derive", "cargo"] }
-datafusion = { path = "../datafusion/core", version = "16.0.0" }
+datafusion = { path = "../datafusion/core", version = "16.1.0" }
 dirs = "4.0.0"
 env_logger = "0.9"
 mimalloc = { version = "0.1", default-features = false }

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-examples"
 description = "DataFusion usage examples"
-version = "16.0.0"
+version = "16.1.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]

--- a/datafusion/CHANGELOG.md
+++ b/datafusion/CHANGELOG.md
@@ -19,6 +19,15 @@
 
 # Changelog
 
+## [16.1.0](https://github.com/apache/arrow-datafusion/tree/16.1.0) (2023-01-19)
+
+[Full Changelog](https://github.com/apache/arrow-datafusion/compare/16.1.0-rc1...16.0.0)
+
+**Merged pull requests:**
+
+- Fix column indices in EnforceDistribution optimizer in Partial AggregateMode \(\#4878\) [\#4959](https://github.com/apache/arrow-datafusion/pull/4959)
+- Make it able to specify a session id for SessionState \(\#4933\) [\#4951](https://github.com/apache/arrow-datafusion/pull/4951)
+
 ## [16.0.0](https://github.com/apache/arrow-datafusion/tree/16.0.0) (2023-01-12)
 
 [Full Changelog](https://github.com/apache/arrow-datafusion/compare/16.0.0-rc1...16.0.0)

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-common"
 description = "Common functionality for DataFusion query engine"
-version = "16.0.0"
+version = "16.1.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 readme = "README.md"

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion"
 description = "DataFusion is an in-memory query engine that uses Apache Arrow as the memory model"
-version = "16.0.0"
+version = "16.1.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 readme = "../../README.md"
@@ -64,13 +64,13 @@ bytes = "1.1"
 bzip2 = { version = "0.4.3", optional = true }
 chrono = { version = "0.4.23", default-features = false }
 dashmap = "5.4.0"
-datafusion-common = { path = "../common", version = "16.0.0", features = ["parquet", "object_store"] }
-datafusion-expr = { path = "../expr", version = "16.0.0" }
-datafusion-jit = { path = "../jit", version = "16.0.0", optional = true }
-datafusion-optimizer = { path = "../optimizer", version = "16.0.0" }
-datafusion-physical-expr = { path = "../physical-expr", version = "16.0.0" }
-datafusion-row = { path = "../row", version = "16.0.0" }
-datafusion-sql = { path = "../sql", version = "16.0.0" }
+datafusion-common = { path = "../common", version = "16.1.0", features = ["parquet", "object_store"] }
+datafusion-expr = { path = "../expr", version = "16.1.0" }
+datafusion-jit = { path = "../jit", version = "16.1.0", optional = true }
+datafusion-optimizer = { path = "../optimizer", version = "16.1.0" }
+datafusion-physical-expr = { path = "../physical-expr", version = "16.1.0" }
+datafusion-row = { path = "../row", version = "16.1.0" }
+datafusion-sql = { path = "../sql", version = "16.1.0" }
 flate2 = { version = "1.0.24", optional = true }
 futures = "0.3"
 glob = "0.3.0"

--- a/datafusion/core/src/execution/context.rs
+++ b/datafusion/core/src/execution/context.rs
@@ -1585,6 +1585,12 @@ impl SessionState {
             })
     }
 
+    /// Replace the random session id.
+    pub fn with_session_id(mut self, session_id: String) -> Self {
+        self.session_id = session_id;
+        self
+    }
+
     /// Replace the default query planner
     pub fn with_query_planner(
         mut self,

--- a/datafusion/core/src/physical_optimizer/dist_enforcement.rs
+++ b/datafusion/core/src/physical_optimizer/dist_enforcement.rs
@@ -431,11 +431,22 @@ fn reorder_aggregate_keys(
                     None
                 };
                 if let Some(partial_agg) = new_partial_agg {
-                    let mut new_group_exprs = vec![];
-                    for idx in positions.into_iter() {
-                        new_group_exprs.push(group_by.expr()[idx].clone());
-                    }
-                    let new_group_by = PhysicalGroupBy::new_single(new_group_exprs);
+                    // Build new group expressions that correspond to the output of partial_agg
+                    let new_final_group: Vec<Arc<dyn PhysicalExpr>> =
+                        partial_agg.output_group_expr();
+                    let new_group_by = PhysicalGroupBy::new_single(
+                        new_final_group
+                            .iter()
+                            .enumerate()
+                            .map(|(i, expr)| {
+                                (
+                                    expr.clone(),
+                                    partial_agg.group_expr().expr()[i].1.clone(),
+                                )
+                            })
+                            .collect(),
+                    );
+
                     let new_final_agg = Arc::new(AggregateExec::try_new(
                         AggregateMode::FinalPartitioned,
                         new_group_by,
@@ -1494,7 +1505,7 @@ mod tests {
         let expected = &[
             "HashJoinExec: mode=Partitioned, join_type=Inner, on=[(Column { name: \"b1\", index: 1 }, Column { name: \"b\", index: 0 }), (Column { name: \"a1\", index: 0 }, Column { name: \"a\", index: 1 })]",
             "ProjectionExec: expr=[a1@1 as a1, b1@0 as b1]",
-            "AggregateExec: mode=FinalPartitioned, gby=[b1@1 as b1, a1@0 as a1], aggr=[]",
+            "AggregateExec: mode=FinalPartitioned, gby=[b1@0 as b1, a1@1 as a1], aggr=[]",
             "RepartitionExec: partitioning=Hash([Column { name: \"b1\", index: 0 }, Column { name: \"a1\", index: 1 }], 10)",
             "AggregateExec: mode=Partial, gby=[b@1 as b1, a@0 as a1], aggr=[]",
             "ParquetExec: limit=None, partitions={1 group: [[x]]}, projection=[a, b, c, d, e]",
@@ -2057,7 +2068,7 @@ mod tests {
             "SortExec: [b3@1 ASC,a3@0 ASC]",
             "ProjectionExec: expr=[a1@0 as a3, b1@1 as b3]",
             "ProjectionExec: expr=[a1@1 as a1, b1@0 as b1]",
-            "AggregateExec: mode=FinalPartitioned, gby=[b1@1 as b1, a1@0 as a1], aggr=[]",
+            "AggregateExec: mode=FinalPartitioned, gby=[b1@0 as b1, a1@1 as a1], aggr=[]",
             "RepartitionExec: partitioning=Hash([Column { name: \"b1\", index: 0 }, Column { name: \"a1\", index: 1 }], 10)",
             "AggregateExec: mode=Partial, gby=[b@1 as b1, a@0 as a1], aggr=[]",
             "ParquetExec: limit=None, partitions={1 group: [[x]]}, projection=[a, b, c, d, e]",

--- a/datafusion/core/tests/sql/joins.rs
+++ b/datafusion/core/tests/sql/joins.rs
@@ -2810,3 +2810,61 @@ async fn type_coercion_join_with_filter_and_equi_expr() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_cross_join_to_groupby_with_different_key_ordering() -> Result<()> {
+    // Regression test for GH #4873
+    let col1 = Arc::new(StringArray::from(vec![
+        "A", "A", "A", "A", "A", "A", "A", "A", "BB", "BB", "BB", "BB",
+    ])) as ArrayRef;
+
+    let col2 =
+        Arc::new(UInt64Array::from(vec![1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6])) as ArrayRef;
+
+    let col3 =
+        Arc::new(UInt64Array::from(vec![1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])) as ArrayRef;
+
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("col1", DataType::Utf8, true),
+        Field::new("col2", DataType::UInt64, true),
+        Field::new("col3", DataType::UInt64, true),
+    ])) as SchemaRef;
+
+    let batch = RecordBatch::try_new(schema.clone(), vec![col1, col2, col3]).unwrap();
+    let mem_table = MemTable::try_new(schema, vec![vec![batch]]).unwrap();
+
+    // Create context and register table
+    let ctx = SessionContext::new();
+    ctx.register_table("tbl", Arc::new(mem_table)).unwrap();
+
+    let sql = "select col1, col2, coalesce(sum_col3, 0) as sum_col3 \
+                     from (select distinct col2 from tbl) AS q1 \
+                     cross join (select distinct col1 from tbl) AS q2 \
+                     left outer join (SELECT col1, col2, sum(col3) as sum_col3 FROM tbl GROUP BY col1, col2) AS q3 \
+                     USING(col2, col1) \
+                     ORDER BY col1, col2";
+
+    let expected = vec![
+        "+------+------+----------+",
+        "| col1 | col2 | sum_col3 |",
+        "+------+------+----------+",
+        "| A    | 1    | 2        |",
+        "| A    | 2    | 2        |",
+        "| A    | 3    | 2        |",
+        "| A    | 4    | 2        |",
+        "| A    | 5    | 0        |",
+        "| A    | 6    | 0        |",
+        "| BB   | 1    | 0        |",
+        "| BB   | 2    | 0        |",
+        "| BB   | 3    | 0        |",
+        "| BB   | 4    | 0        |",
+        "| BB   | 5    | 2        |",
+        "| BB   | 6    | 2        |",
+        "+------+------+----------+",
+    ];
+
+    let results = execute_to_batches(&ctx, sql).await;
+    assert_batches_sorted_eq!(expected, &results);
+
+    Ok(())
+}

--- a/datafusion/core/tests/sqllogictests/test_files/aggregate.slt
+++ b/datafusion/core/tests/sqllogictests/test_files/aggregate.slt
@@ -1183,3 +1183,47 @@ query RRRR
 select var(sq.column1), var_pop(sq.column1), stddev(sq.column1), stddev_pop(sq.column1) from (values (1.0), (3.0)) as sq;
 ----
 2 1 1.4142135623730951 1
+
+
+# sum / count for all nulls
+statement ok
+create table the_nulls as values (null::bigint, 1), (null::bigint, 1), (null::bigint, 2);
+
+# counts should be zeros (even for nulls)
+query II
+SELECT count(column1), column2 from the_nulls group by column2 order by column2;
+----
+0 1
+0 2
+
+# sums should be null
+query II
+SELECT sum(column1), column2 from the_nulls group by column2 order by column2;
+----
+NULL 1
+NULL 2
+
+# avg should be null
+query II
+SELECT avg(column1), column2 from the_nulls group by column2 order by column2;
+----
+NULL 1
+NULL 2
+
+# min should be null
+query II
+SELECT min(column1), column2 from the_nulls group by column2 order by column2;
+----
+NULL 1
+NULL 2
+
+# max should be null
+query II
+SELECT max(column1), column2 from the_nulls group by column2 order by column2;
+----
+NULL 1
+NULL 2
+
+
+statement ok
+drop table the_nulls;

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-expr"
 description = "Logical plan and expression representation for DataFusion query engine"
-version = "16.0.0"
+version = "16.1.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 readme = "README.md"
@@ -37,6 +37,6 @@ path = "src/lib.rs"
 [dependencies]
 ahash = { version = "0.8", default-features = false, features = ["runtime-rng"] }
 arrow = { version = "29.0.0", default-features = false }
-datafusion-common = { path = "../common", version = "16.0.0" }
+datafusion-common = { path = "../common", version = "16.1.0" }
 log = "^0.4"
 sqlparser = "0.30"

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-jit"
 description = "Just In Time (JIT) compilation support for DataFusion query engine"
-version = "16.0.0"
+version = "16.1.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 readme = "README.md"
@@ -41,7 +41,7 @@ cranelift = "0.89.0"
 cranelift-jit = "0.89.0"
 cranelift-module = "0.89.0"
 cranelift-native = "0.89.0"
-datafusion-common = { path = "../common", version = "16.0.0", features = ["jit"] }
-datafusion-expr = { path = "../expr", version = "16.0.0" }
+datafusion-common = { path = "../common", version = "16.1.0", features = ["jit"] }
+datafusion-expr = { path = "../expr", version = "16.1.0" }
 
 parking_lot = "0.12"

--- a/datafusion/optimizer/Cargo.toml
+++ b/datafusion/optimizer/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-optimizer"
 description = "DataFusion Query Optimizer"
-version = "16.0.0"
+version = "16.1.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 readme = "README.md"
@@ -40,14 +40,14 @@ unicode_expressions = []
 arrow = { version = "29.0.0", features = ["prettyprint"] }
 async-trait = "0.1.41"
 chrono = { version = "0.4.23", default-features = false }
-datafusion-common = { path = "../common", version = "16.0.0" }
-datafusion-expr = { path = "../expr", version = "16.0.0" }
-datafusion-physical-expr = { path = "../physical-expr", version = "16.0.0" }
+datafusion-common = { path = "../common", version = "16.1.0" }
+datafusion-expr = { path = "../expr", version = "16.1.0" }
+datafusion-physical-expr = { path = "../physical-expr", version = "16.1.0" }
 hashbrown = { version = "0.13", features = ["raw"] }
 log = "^0.4"
 regex-syntax = "0.6.28"
 
 [dev-dependencies]
 ctor = "0.1.22"
-datafusion-sql = { path = "../sql", version = "16.0.0" }
+datafusion-sql = { path = "../sql", version = "16.1.0" }
 env_logger = "0.10.0"

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-physical-expr"
 description = "Physical expression implementation for DataFusion query engine"
-version = "16.0.0"
+version = "16.1.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 readme = "README.md"
@@ -46,9 +46,9 @@ arrow-schema = "29.0.0"
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
 chrono = { version = "0.4.23", default-features = false }
-datafusion-common = { path = "../common", version = "16.0.0" }
-datafusion-expr = { path = "../expr", version = "16.0.0" }
-datafusion-row = { path = "../row", version = "16.0.0" }
+datafusion-common = { path = "../common", version = "16.1.0" }
+datafusion-expr = { path = "../expr", version = "16.1.0" }
+datafusion-row = { path = "../row", version = "16.1.0" }
 half = { version = "2.1", default-features = false }
 hashbrown = { version = "0.13", features = ["raw"] }
 indexmap = "1.9.2"

--- a/datafusion/physical-expr/src/aggregate/average.rs
+++ b/datafusion/physical-expr/src/aggregate/average.rs
@@ -261,7 +261,7 @@ impl RowAccumulator for AvgRowAccumulator {
         assert_eq!(self.sum_datatype, DataType::Float64);
         Ok(match accessor.get_u64_opt(self.state_index()) {
             None => ScalarValue::Float64(None),
-            Some(0) => ScalarValue::Float64(Some(0.0)),
+            Some(0) => ScalarValue::Float64(None),
             Some(n) => ScalarValue::Float64(
                 accessor
                     .get_f64_opt(self.state_index() + 1)

--- a/datafusion/proto/Cargo.toml
+++ b/datafusion/proto/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-proto"
 description = "Protobuf serialization of DataFusion logical plan expressions"
-version = "16.0.0"
+version = "16.1.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 readme = "README.md"
@@ -42,9 +42,9 @@ json = ["pbjson", "serde", "serde_json"]
 [dependencies]
 arrow = "29.0.0"
 chrono = { version = "0.4", default-features = false }
-datafusion = { path = "../core", version = "16.0.0" }
-datafusion-common = { path = "../common", version = "16.0.0" }
-datafusion-expr = { path = "../expr", version = "16.0.0" }
+datafusion = { path = "../core", version = "16.1.0" }
+datafusion-common = { path = "../common", version = "16.1.0" }
+datafusion-expr = { path = "../expr", version = "16.1.0" }
 object_store = { version = "0.5.0" }
 parking_lot = { version = "0.12" }
 pbjson = { version = "0.5", optional = true }

--- a/datafusion/row/Cargo.toml
+++ b/datafusion/row/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-row"
 description = "Row backed by raw bytes for DataFusion query engine"
-version = "16.0.0"
+version = "16.1.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 readme = "README.md"
@@ -38,7 +38,7 @@ jit = ["datafusion-jit"]
 
 [dependencies]
 arrow = "29.0.0"
-datafusion-common = { path = "../common", version = "16.0.0" }
-datafusion-jit = { path = "../jit", version = "16.0.0", optional = true }
+datafusion-common = { path = "../common", version = "16.1.0" }
+datafusion-jit = { path = "../jit", version = "16.1.0", optional = true }
 paste = "^1.0"
 rand = "0.8"

--- a/datafusion/sql/Cargo.toml
+++ b/datafusion/sql/Cargo.toml
@@ -18,7 +18,7 @@
 [package]
 name = "datafusion-sql"
 description = "DataFusion SQL Query Planner"
-version = "16.0.0"
+version = "16.1.0"
 homepage = "https://github.com/apache/arrow-datafusion"
 repository = "https://github.com/apache/arrow-datafusion"
 readme = "README.md"
@@ -38,7 +38,7 @@ unicode_expressions = []
 
 [dependencies]
 arrow-schema = "29.0.0"
-datafusion-common = { path = "../common", version = "16.0.0" }
-datafusion-expr = { path = "../expr", version = "16.0.0" }
+datafusion-common = { path = "../common", version = "16.1.0" }
+datafusion-expr = { path = "../expr", version = "16.1.0" }
 log = "^0.4"
 sqlparser = "0.30"


### PR DESCRIPTION
Branch based on DataFusion 16.1.0, with additional fixes and backports. Includes:

 - https://github.com/apache/arrow-datafusion/pull/5008
